### PR TITLE
Revert to typed property

### DIFF
--- a/src/JviguyGames/BiggusDickus/PM3/Main.php
+++ b/src/JviguyGames/BiggusDickus/PM3/Main.php
@@ -15,11 +15,10 @@ use function imagecreatefrompng;
 
 class Main implements Listener {
 
-    /** @var Skin $skin */
-    public $skin;
+    /** @var Skin $skin the dick geo / skin */
+    public Skin $skin;
 
-    public function __construct(public Loader $loader){
-    }
+    public function __construct(public Loader $loader){}
 
     public function onEnable() : void {
         $this->loader->saveResource("dildo.png");


### PR DESCRIPTION
ItsNiseGuy changed the typed property because Poggit was giving a lint error, Poggit checks are still on PHP 7.3 meaning the code is valid and all that did was negatively impact performance.

This PR reverts it to a typed property which is how it should be because the core minimum in plugin.yml is PHP 8, not PHP 7.3.